### PR TITLE
df script zip update

### DIFF
--- a/scripts/Mods/darkness_falls.sh
+++ b/scripts/Mods/darkness_falls.sh
@@ -28,9 +28,13 @@ fi
 downloadRelease() {
     $regex_pattern="zip$"
     if [[ "$DL_LINK" =~ $regex_pattern ]]; then
-        curl "$DL_LINK" --output df-mod.zip -d darknessFalls-temp/
-        unzip "$DL_LINK" -d darknessFalls-temp/
-        rm df-mod.zip
+        if ![[ -f $DL_LINK ]]; then
+            touch $DL_LINK
+            curl "$DL_LINK" --output df-mod.zip -d darknessFalls-temp/
+            unzip "$DL_LINK" -d darknessFalls-temp/
+            rm df-mod.zip
+        else
+            echo "[Darkness Falls] Already downloaded zipped release, skipping..."
     else
         git clone --progress "$DL_LINK" darknessFalls-temp/
     fi

--- a/scripts/Mods/darkness_falls.sh
+++ b/scripts/Mods/darkness_falls.sh
@@ -35,6 +35,7 @@ downloadRelease() {
             rm df-mod.zip
         else
             echo "[Darkness Falls] Already downloaded zipped release, skipping..."
+        fi
     else
         git clone --progress "$DL_LINK" darknessFalls-temp/
     fi


### PR DESCRIPTION
Updated DF script that looks for a zip to download. This currently runs every time and downloads the 12GB zip. If already downloaded we want to skip. If the version changes, we will want to download again. If this works, then a todo would be to delete the mod and pull the new version down.